### PR TITLE
tests: allow running from different directory

### DIFF
--- a/tests/test_complex.py
+++ b/tests/test_complex.py
@@ -5,6 +5,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')
 from kdl import parse
 
 def test_from_file():
+	os.chdir(os.path.dirname(__file__))
 	with open('complex.kdl', 'r') as fp:
 		doc = parse(fp)
 	if sys.version_info.major == 3:


### PR DESCRIPTION
Right now they assume we are in the tests directory, let's make it able
to run it from other directory.

Signed-off-by: Filipe Laíns <lains@riseup.net>