### PR TITLE
Exclude slash from valid identifier example

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ smile "😁"
 "!@#$@$%Q#$%~@!40" "1.2.3" "!!!!!"=true
 
 // The following is a legal bare identifier:
-foo123~!@#$%^&*.:'|/?+ "weeee"
+foo123~!@#$%^&*.:'|?+ "weeee"
 
 // And you can also use unicode!
 ノード　お名前="☜(ﾟヮﾟ☜)"


### PR DESCRIPTION
Bare identifiers should exclude 

> Any of `\/(){}<>;[]=,"`